### PR TITLE
Fix generating static files

### DIFF
--- a/src/Command/Build.php
+++ b/src/Command/Build.php
@@ -28,7 +28,11 @@ class Build implements \Soushi\Command
     private function generatePages()
     {
         foreach ($this->aggregator->pages() as $page) {
-            $path = "{$this->dstDir}/{$page->path()}.html";
+            if ($page->isIndexPage()) {
+                $path = "{$this->dstDir}/{$page->path()}.html";
+            } else {
+                $path = "{$this->dstDir}/{$page->path()}/index.html";
+            }
             $html = $this->template->render(
                 $page->template(),
                 array_merge(

--- a/src/File/Page.php
+++ b/src/File/Page.php
@@ -19,6 +19,11 @@ class Page implements \Soushi\File
         return true;
     }
 
+    function isIndexPage(): bool
+    {
+        return $this->path() === 'index' || preg_match('#\/index\z#', $this->path());
+    }
+
     function metadata(): array
     {
         return $this->document()->getYAML();

--- a/tests/Command/BuildTest.php
+++ b/tests/Command/BuildTest.php
@@ -30,8 +30,8 @@ class BuildTest extends TestCase
         $init->execute();
 
         $this->assertFileExists(self::$buildDir . "/index.html");
-        $this->assertFileExists(self::$buildDir . "/subdir/foo.html");
-        $this->assertFileExists(self::$buildDir . "/subdir/bar.html");
+        $this->assertFileExists(self::$buildDir . "/subdir/foo/index.html");
+        $this->assertFileExists(self::$buildDir . "/subdir/bar/index.html");
         $this->assertFileExists(self::$buildDir . "/css/main.css");
         $this->assertFileExists(self::$buildDir . "/js/main.js");
     }

--- a/tests/File/PageTest.php
+++ b/tests/File/PageTest.php
@@ -16,6 +16,13 @@ class PageTest extends TestCase
         $this->assertTrue($page->isPage());
     }
 
+    function testIsIndexPage()
+    {
+        $aggregator = new \Soushi\Aggregator(dirname(__FILE__, 2) . "/assets/source");
+        $this->assertTrue($aggregator->fetch('index')->isIndexPage());
+        $this->assertFalse($aggregator->fetch('subdir/bar')->isIndexPage());
+    }
+
     function testMetadata()
     {
         $page = new Soushi\File\Page(new \SplFileInfo(dirname(__FILE__, 2) . "/assets/source/index.md"));


### PR DESCRIPTION
Fix the path of generated static files.

### source files

```
source
├── foo.md
├── bar
│   ├── index.md
│   └── baz.md
└── index.md

```

### generated static files

before
```
build
├── foo.html
├── bar
│   ├── index.html
│   └── baz.html
└── index.html
```

after
```
build
├── foo
│   └── index.html
├── bar
│   ├── index.html
│   └── baz
│      └── index.html
└── index.html
```

We can browse with the same URL as the dynamic web site :-)