### PR TITLE
Fix "Class 'Soushi\Cli' not found" on global installation

### DIFF
--- a/bin/soushi
+++ b/bin/soushi
@@ -1,5 +1,15 @@
 #!/usr/bin/env php
 <?php
+foreach (
+    [
+        dirname(__DIR__, 4) . '/vendor/autoload.php',
+        dirname(__DIR__) . '/vendor/autoload.php',
+    ] as $file
+) {
+    if (file_exists($file)) {
+        require_once $file;
+        break;
+    }
+}
 
-require_once 'vendor/autoload.php';
 (new Soushi\Cli())->run($argv);


### PR DESCRIPTION

```bash
# Install soushi globally
$ composer global require kentaro/soushi
Changed current directory to /root/.composer
Using version ^0.0.3 for kentaro/soushi
./composer.json has been created
...
...


# Set $PATH
$ export PATH=$PATH:~/.composer/vendor/bin

# Build my docs
$ ~/my_project
$ soushi build docs

Fatal error: Uncaught Error: Class 'Soushi\Cli' not found in /root/.composer/vendor/kentaro/soushi/bin/soushi on line 5

Error: Class 'Soushi\Cli' not found in /root/.composer/vendor/kentaro/soushi/bin/soushi on line 5

Call Stack:
    0.0001     388176   1. {main}() /root/.composer/vendor/kentaro/soushi/bin/soushi:0
```